### PR TITLE
Switch to fork of Dataset-JSON viewer hosted on GitHub Pages

### DIFF
--- a/json-viewer.qmd
+++ b/json-viewer.qmd
@@ -1,0 +1,17 @@
+---
+title: "Dataset JSON Viewer"
+format: html
+filters:
+  - shinylive
+---
+
+In this page you will find the Dataset-JSON Viewer Shiny application authored by Sebastià Barceló & Hugo Signol. This is a powerful and user-friendly Shiny application for exploring and analyzing JSON data sets with interactive features and comprehensive data visualization capabilities. For additional details please refer to the [usage guide](https://github.com/sbarcelo777/Dataset-JSON-hackathon/blob/master/README.md#-user-guide) from the project's [GitHub repository](https://github.com/sbarcelo777/Dataset-JSON-hackathon/).
+
+::: {.callout-note}
+This is a copy of the application powered by `{shinylive}` and WebAssembly. No modifications to the application code base have been made.
+:::
+
+
+```{=html}
+<iframe width="1480" height="1200" src="https://rpodcast.github.io/Dataset-JSON-hackathon/" title="Pilot 4 App"></iframe>
+```

--- a/viewer.qmd
+++ b/viewer.qmd
@@ -5,11 +5,12 @@ format:
     page-layout: full
 ---
 
-This JSON Viewer is a [Shiny](https://shiny.posit.co/)-based solution originally developed for the 3rd [CDISC Dataset-JSON Viewer Hackathon](https://www.linkedin.com/pulse/results-from-cosa-dataset-json-viewer-hackathon-sam-hume-kgbge) for which it won an honorable mention. It allows you to interactively explore and analyze CDISC [Dataset-JSON](https://www.cdisc.org/standards/data-exchange/dataset-json) data. Credit goes to the [original developers](https://github.com/sbarcelo777/Dataset-JSON-hackathon?tab=readme-ov-file#-authors) of the application. The repo for the app can be found [here](https://github.com/sbarcelo777/Dataset-JSON-hackathon). 
+This JSON Viewer is a [Shiny](https://shiny.posit.co/)-based solution originally developed for the 3rd [CDISC Dataset-JSON Viewer Hackathon](https://www.linkedin.com/pulse/results-from-cosa-dataset-json-viewer-hackathon-sam-hume-kgbge) for which it won an honorable mention. It allows you to interactively explore and analyze CDISC [Dataset-JSON](https://www.cdisc.org/standards/data-exchange/dataset-json) data. Credit goes to the [original developers](https://github.com/sbarcelo777/Dataset-JSON-hackathon?tab=readme-ov-file#-authors) of the application. The specific application below is based on a fork of the original application with selected example JSON data files pre-loaded in the user interface for convenience. The repository for this version of the app can be found [here](https://github.com/rpodcast/Dataset-JSON-hackathon). 
 
 ```{r}
 #| echo: FALSE
 #| message: FALSE
+#| eval: false
 
 library(htmltools)
 source("R/create_shinylive_url.R")
@@ -28,15 +29,15 @@ if (FALSE){
 shinylive_url <- url_encode_dir(repo_path, mode = "app", exclude = "rsconnect/|html|svg")
 ```
 
-It is embedded below with the help of [shinylive.io](https://shiny.posit.co/py/docs/shinylive.html). The app should load below; otherwise, please click [here](`{r} shinylive_url`).
+It is embedded below with the help of [shinylive.io](https://shiny.posit.co/py/docs/shinylive.html). The app should load below; otherwise, please click [here](https://rpodcast.github.io/Dataset-JSON-hackathon/).
 
 ```{r}
 #| echo: FALSE
 #| message: FALSE
 # 
-tags$iframe(
+htmltools::tags$iframe(
   title = "JSON Viewer",
-  src = shinylive_url,
+  src = "https://rpodcast.github.io/Dataset-JSON-hackathon/",
   style = "width: 100%; height: 600px; border: none;",
   allowfullscreen = FALSE
 )


### PR DESCRIPTION
This PR makes the switch from the original Dataset-JSON data viewer to a custom fork of the application created by me (@rpodcast) which preloads example dataset-json data files automatically when the app launches. The repository for this forked version of the application can be found [here](https://github.com/rpodcast/Dataset-JSON-hackathon).